### PR TITLE
bugfix for service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,7 +9,6 @@ class bind::service (
     hasstatus => true,
     enable    => true,
     ensure    => running,
-    path      => $::path,
     restart   => "service ${servicename} reload"
   }
 


### PR DESCRIPTION
the path param in service resources behaves differently from exec
resources, resulting in the service not being able to start/restart the
bind9 service
