### PR TITLE
bind service and log dir dependency fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class bind (
     group   => $bind::params::bindgroup,
     mode    => '0770',
     seltype => 'var_log_t',
+    before  => Class['bind::service'],
   }
 
 }


### PR DESCRIPTION
When provisioning VM instances from scratch with this module end up with errors in the syslog showing that the logdir was not present, when the service was started.
