### PR TITLE
Add support for $check_names

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -36,6 +36,8 @@
 #   Array of IP addrs or ACLs to allow recursion from. Default: empty
 #  $allow_transfer:
 #   Array of IP addrs or ACLs to allow transfer to. Default: empty
+#  $check_names:
+#   Array of check-names strings. Example: [ 'master ignore' ]. Default: empty
 #  $dnssec_enable:
 #   Enable DNSSEC support. Default: 'yes'
 #  $dnssec_validation:
@@ -87,6 +89,7 @@ define bind::server::conf (
   $recursion          = 'yes',
   $allow_recursion    = [],
   $allow_transfer     = [],
+  $check_names        = [],
   $dnssec_enable      = 'yes',
   $dnssec_validation  = 'yes',
   $dnssec_lookaside   = 'auto',

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -59,6 +59,11 @@ options {
 <% if !@allow_transfer.empty? -%>
     allow-transfer { <%= @allow_transfer.join("; ") %>; };
 <% end -%>
+<% if !@check_names.empty? -%>
+<% @check_names.each do |line| -%>
+    check-names "<%= line %>";
+<% end -%>
+<% end -%>
 
     dnssec-enable <%= @dnssec_enable %>;
     dnssec-validation <%= @dnssec_validation %>;


### PR DESCRIPTION
Support check-names in the options section of named.conf.erb by using an array of string in the bind::server::conf class.
