### PR TITLE
Remove quotes for check-names.

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -61,7 +61,7 @@ options {
 <% end -%>
 <% if !@check_names.empty? -%>
 <% @check_names.each do |line| -%>
-    check-names "<%= line %>";
+    check-names <%= line %>;
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
I missed commiting a fix for the previous pull of check-names feature. Sorry about that!

Incorrect:

```
check-names "master ignore";
```

Correct:

```
check-names master ignore;
```
