### PR TITLE
The rfc1912 zones file has different path on osfamily debian.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class bind::params {
       $servicename       = 'named'
       $binduser          = 'root'
       $bindgroup         = 'named'
+      $rfc1912_file      = '/etc/named.rfc1912.zones'
     }
     'Debian',
     'Ubuntu': {
@@ -17,12 +18,14 @@ class bind::params {
       $servicename       = 'bind9'
       $binduser          = 'bind'
       $bindgroup         = 'bind'
+      $rfc1912_file      = '/etc/bind/zones.rfc1918'
     }
     default: {
       $packagenameprefix = 'bind'
       $servicename       = 'named'
       $binduser          = 'root'
       $bindgroup         = 'named'
+      $rfc1912_file      = '/etc/named.rfc1912.zones'
     }
   }
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -81,6 +81,7 @@ define bind::server::conf (
   $forwarders         = [],
   $directory          = '/var/named',
   $version            = undef,
+  $rfc1912_file       = $bind::params::rfc1912_file,
   $dump_file          = '/var/named/data/cache_dump.db',
   $statistics_file    = '/var/named/data/named_stats.txt',
   $memstatistics_file = '/var/named/data/named_mem_stats.txt',

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -104,7 +104,9 @@ zone "<%= key %>" IN {
 
 <% end -%>
 <% end -%>
-include "/etc/named.rfc1912.zones";
+<% if @rfc1912_file -%>
+include "<%= @rfc1912_file %>";
+<% end -%>
 <% if !@includes.empty? -%>
 <% @includes.each do |filename| -%>
 include "<%= filename %>";


### PR DESCRIPTION
Fix rfc1912 zones file path on Ubuntu, Debian.
