### PR TITLE
Add configuration of additional paths to allow for better debian-style use.

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -89,6 +89,7 @@ define bind::server::conf (
   $directory              = '/var/named',
   $conf_directory         = '/etc',
   $data_directory         = "${directory}",
+  $root_hints_file        = "named.ca",
   $managed_keys_directory = undef,
   $hostname               = undef,
   $server_id              = undef,

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -147,7 +147,7 @@ view "<%= key %>" {
 <% if @recursion == 'yes' -%>
 zone "." IN {
     type hint;
-    file "named.ca";
+    file "<%=@root_hints_file %>";
 };
 
 <% end -%>


### PR DESCRIPTION
These three commits make dump_file, statistics_file and memstatistics_file depend on data_directory, which in turn is a copy of directory (for backwards-compat).

conf_directory and root_hints_file are added to prevent hard-coded paths in the template.
