### PR TITLE
add notify parameter to config template

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -101,6 +101,7 @@ define bind::server::conf (
   $allow_transfer         = [],
   $check_names            = [],
   $extra_options          = {},
+  $notify                 = 'yes',
   $dnssec_enable          = 'yes',
   $dnssec_validation      = 'yes',
   $dnssec_lookaside       = 'auto',

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -68,6 +68,7 @@ options {
 <% if !@allow_transfer.empty? -%>
     allow-transfer { <%= @allow_transfer.join("; ") %>; };
 <% end -%>
+    notify <%= @notify %>;
 <% if !@check_names.empty? -%>
 <% @check_names.each do |line| -%>
     check-names <%= line %>;


### PR DESCRIPTION
self explanatory. can be useful if you don't want to specify notify = no in all zones, and you don't want all slaves to inter-notify each other (the default behavior).
