### PR TITLE
do not include non-existing file on Debian recursive nameservers

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -145,10 +145,13 @@ view "<%= key %>" {
 <% else -%><%# end views, start no views -%>
 
 <% if @recursion == 'yes' -%>
+<% if @osfamily != 'Debian' -%>
+
 zone "." IN {
     type hint;
     file "named.ca";
 };
+<% end -%>
 
 <% end -%>
 <% if !@zones.empty? -%>
@@ -162,7 +165,9 @@ zone "<%= key %>" IN {
 <% end -%>
 <% end -%>
 <% if @recursion == 'yes' -%>
+<% if @osfamily != 'Debian' -%>
 include "/etc/named.rfc1912.zones";
+<% end -%>
 <% end -%>
 <% end -%><%# end no views -%>
 <% if !@includes.empty? -%>


### PR DESCRIPTION
this file is distributed as /etc/bind/named.conf.default-zones on
Debian. it's also included by default in named.conf so it makes little
sense in deploying it here again.
