### PR TITLE
Debian support + logging setings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,24 +8,40 @@ class bind::params {
       $servicename       = 'named'
       $binduser          = 'root'
       $bindgroup         = 'named'
+      $directory         = '/var/named'
+      $zonedir           = '/var/named'
+      $rfc1912_zones     = '/etc/named.rfc1912.zones'
+      $bindkeys_file     = '/etc/named.iscdlv.key'
     }
     'Debian': {
       $packagenameprefix = 'bind9'
       $servicename       = 'bind9'
       $binduser          = 'bind'
       $bindgroup         = 'bind'
+      $directory         = '/var/cache/bind'
+      $zonedir           = '/etc/bind'
+      $rfc1912_zones     = '/etc/bind/named.conf.default-zones'
+      $bindkeys_file     = '/etc/bind/bind.keys'
     }
     'Freebsd': {
       $packagenameprefix = 'bind910'
       $servicename       = 'named'
       $binduser          = 'bind'
       $bindgroup         = 'bind'
+      $directory         = '/var/named'
+      $zonedir           = '/var/named'
+      $rfc1912_zones     = '/etc/named.rfc192.zones'
+      $bindkeys_file     = '/etc/named.iscdlv.key'
     }
     default: {
       $packagenameprefix = 'bind'
       $servicename       = 'named'
       $binduser          = 'root'
       $bindgroup         = 'named'
+      $directory         = '/var/named'
+      $zonedir           = '/var/named'
+      $rfc1912_zones     = '/etc/named.rfc1912.zones'
+      $bindkeys_file     = '/etc/named.iscdlv.key'
     }
   }
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -123,6 +123,7 @@ define bind::server::conf (
 
   # Everything is inside a single template
   file { $title:
+    require => Class['bind::package'],
     notify  => Class['bind::service'],
     content => template('bind/named.conf.erb'),
   }

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -30,6 +30,10 @@
 #   ID returned for id.server TXT in CHAOS. Default: undef, empty
 #  $version:
 #   Version string override text. Default: none
+#  $logging:
+#   Enable logging. Default: 'yes'
+#  $logfile:
+#   Logfile path. Default: '/var/log/named/named.log'
 #  $dump_file:
 #   Dump file for the server. Default: "${bind::params::directory}/data/cache_dump.db"
 #  $statistics_file:
@@ -97,6 +101,8 @@ define bind::server::conf (
   $hostname               = undef,
   $server_id              = undef,
   $version                = undef,
+  $logging                = 'yes',
+  $logfile                = '/var/log/named/named.log',
   $dump_file              = "${bind::params::directory}/data/cache_dump.db",
   $statistics_file        = "${bind::params::directory}/data/named_stats.txt",
   $memstatistics_file     = "${bind::params::directory}/data/named_mem_stats.txt",

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -18,7 +18,11 @@
 #  $forwarders:
 #   Array of forwarders IP addresses. Default: empty
 #  $directory:
-#   Base directory for the BIND server. Default: '/var/named'
+#   Base directory for the BIND server. Defaults to os-specific path set in bind::params.
+#  $rfc1912_zones:
+#   BIND server zone configuration file for zones recommended by RFC 1912. Defaults to os-specific path set in bind::params.
+#  $bindkeys_file:
+#   Path to ISC DLV key. Defaults to os-specific path set in bind::params.
 #  $hostname:
 #   Hostname returned for hostname.bind TXT in CHAOS. Set to 'none' to disable.
 #   Default: undef, bind internal default
@@ -27,12 +31,12 @@
 #  $version:
 #   Version string override text. Default: none
 #  $dump_file:
-#   Dump file for the server. Default: '/var/named/data/cache_dump.db'
+#   Dump file for the server. Default: "${bind::params::directory}/data/cache_dump.db"
 #  $statistics_file:
-#   Statistics file for the server. Default: '/var/named/data/named_stats.txt'
+#   Statistics file for the server. Default: "${bind::params::directory}/data/named_stats.txt"
 #  $memstatistics_file:
 #   Memory statistics file for the server.
-#   Default: '/var/named/data/named_mem_stats.txt'
+#   Default: "${bind::params::directory}/data/named_mem_stats.txt"
 #  $allow_query:
 #   Array of IP addrs or ACLs to allow queries from. Default: [ 'localhost' ]
 #  $recursion:
@@ -86,14 +90,16 @@ define bind::server::conf (
   $listen_on_v6_port      = '53',
   $listen_on_v6_addr      = [ '::1' ],
   $forwarders             = [],
-  $directory              = '/var/named',
+  $directory              = $::bind::params::directory,
+  $rfc1912_zones          = $::bind::params::rfc1912_zones,
+  $bindkeys_file          = $::bind::params::bindkeys_file,
   $managed_keys_directory = undef,
   $hostname               = undef,
   $server_id              = undef,
   $version                = undef,
-  $dump_file              = '/var/named/data/cache_dump.db',
-  $statistics_file        = '/var/named/data/named_stats.txt',
-  $memstatistics_file     = '/var/named/data/named_mem_stats.txt',
+  $dump_file              = "${bind::params::directory}/data/cache_dump.db",
+  $statistics_file        = "${bind::params::directory}/data/named_stats.txt",
+  $memstatistics_file     = "${bind::params::directory}/data/named_mem_stats.txt",
   $allow_query            = [ 'localhost' ],
   $allow_query_cache      = [],
   $recursion              = 'yes',

--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -5,7 +5,7 @@
 #
 # Parameters:
 #  $zonedir:
-#    Directory where to store the zone file. Default: '/var/named'
+#    Directory where to store the zone file. Defaults to os-specific path set in bind::params.
 #  $owner:
 #    Zone file user owner. Default: 'root'
 #  $group:
@@ -29,7 +29,7 @@
 #  }
 #
 define bind::server::file (
-  $zonedir     = '/var/named',
+  $zonedir     = $::bind::params::zonedir,
   $owner       = 'root',
   $group       = undef,
   $mode        = '0640',

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -61,7 +61,9 @@ options {
 <% if !@allow_query_cache.empty? -%>
     allow-query-cache { <%= @allow_query_cache.join("; ") %>; };
 <% end -%>
+<% if @recursion -%>
     recursion <%= @recursion %>;
+<% end -%>
 <% if !@allow_recursion.empty? -%>
     allow-recursion { <%= @allow_recursion.join("; ") %>; };
 <% end -%>
@@ -80,9 +82,15 @@ options {
 <% end -%>
 
 <% end -%>
+<% if @dnssec_enable -%>
     dnssec-enable <%= @dnssec_enable %>;
+<% end -%>
+<% if @dnssec_validation -%>
     dnssec-validation <%= @dnssec_validation %>;
+<% end -%>
+<% if @dnssec_lookaside -%>
     dnssec-lookaside <%= @dnssec_lookaside %>;
+<% end -%>
 
     /* Path to ISC DLV key */
     bindkeys-file "/etc/named.iscdlv.key";

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -98,9 +98,10 @@ options {
 <% end -%>
 };
 
+<% if @logging == 'yes' and @logfile -%>
 logging {
     channel main_log {
-        file "/var/log/named/named.log" versions 3 size 5m;
+        file "<%= @logfile %>" versions 3 size 5m;
         severity info;
         print-time yes;
         print-severity yes;
@@ -113,6 +114,8 @@ logging {
         null;
     };
 };
+<% end -%>
+
 <% if !@views.empty? -%>
 
 <% @views.sort_by {|key,value| key}.each do |key,value| -%>

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -92,8 +92,10 @@ options {
     dnssec-lookaside <%= @dnssec_lookaside %>;
 <% end -%>
 
+<% if @bindkeys_file -%>
     /* Path to ISC DLV key */
-    bindkeys-file "/etc/named.iscdlv.key";
+    bindkeys-file "<%= @bindkeys_file %>";
+<% end -%>
 };
 
 logging {
@@ -152,7 +154,7 @@ view "<%= key %>" {
 <% end -%>
 <% else -%><%# end views, start no views -%>
 
-<% if @recursion == 'yes' -%>
+<% if @recursion == 'yes' and @osfamily != 'Debian' -%>
 zone "." IN {
     type hint;
     file "named.ca";
@@ -169,8 +171,8 @@ zone "<%= key %>" IN {
 
 <% end -%>
 <% end -%>
-<% if @recursion == 'yes' -%>
-include "/etc/named.rfc1912.zones";
+<% if @recursion == 'yes' and @rfc1912_zones -%>
+include "<%= @rfc1912_zones %>";
 <% end -%>
 <% end -%><%# end no views -%>
 <% if !@includes.empty? -%>


### PR DESCRIPTION
Hi!
I tried to make your module debian compatible without breaking anything and get rid of mandatory options in template (so things like recursion, dnssec-\* and logging could be just set to undef). Works out of the box with default parameters on Debian/Ubuntu.
