### PR TITLE
Add a service restart parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,9 +16,10 @@
 #  }
 #
 class bind (
-  $chroot            = false,
-  $service_reload    = true,
-  $packagenameprefix = $::bind::params::packagenameprefix,
+  $chroot                  = false,
+  $service_reload          = true,
+  $packagenameprefix       = $::bind::params::packagenameprefix,
+  $service_restart_command = $::bind::params::service_restart_command,
 ) inherits ::bind::params {
 
   # Main package and service
@@ -33,6 +34,7 @@ class bind (
   class { 'bind::service':
     servicename    => $servicename,
     service_reload => $service_reload,
+    service_restart_command => $service_restart_command,
   }
 
   # We want a nice log file which the package doesn't provide a location for

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,28 +4,31 @@ class bind::params {
 
   case $::osfamily {
     'RedHat': {
-      $packagenameprefix = 'bind'
-      $servicename       = 'named'
-      $binduser          = 'root'
-      $bindgroup         = 'named'
+      $packagenameprefix       = 'bind'
+      $servicename             = 'named'
+      $binduser                = 'root'
+      $bindgroup               = 'named'
+      $service_restart_command = "service ${servicename} reload"
     }
     'Debian': {
-      $packagenameprefix = 'bind9'
-      $servicename       = 'bind9'
-      $binduser          = 'bind'
-      $bindgroup         = 'bind'
+      $packagenameprefix       = 'bind9'
+      $servicename             = 'bind9'
+      $binduser                = 'bind'
+      $bindgroup               = 'bind'
+      $service_restart_command = "service ${servicename} reload"
     }
     'Freebsd': {
-      $packagenameprefix = 'bind910'
-      $servicename       = 'named'
-      $binduser          = 'bind'
-      $bindgroup         = 'bind'
+      $packagenameprefix       = 'bind910'
+      $servicename             = 'named'
+      $binduser                = 'bind'
+      $bindgroup               = 'bind'
     }
     default: {
-      $packagenameprefix = 'bind'
-      $servicename       = 'named'
-      $binduser          = 'root'
-      $bindgroup         = 'named'
+      $packagenameprefix       = 'bind'
+      $servicename             = 'named'
+      $binduser                = 'root'
+      $bindgroup               = 'named'
+      $service_restart_command = "service ${servicename} reload"
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,13 +1,14 @@
 # Class: bind::service
 #
 class bind::service (
-  $servicename    = $::bind::params::servicename,
-  $service_reload = true,
+  $servicename             = $::bind::params::servicename,
+  $service_reload          = true,
+  $service_restart_command = $::bind::params::service_restart_command,
 ) inherits ::bind::params {
 
   if $service_reload {
     Service[$servicename] {
-      restart => "service ${servicename} reload",
+      restart => $service_restart_command,
     }
   }
 


### PR DESCRIPTION
This PR creates a parameter for a service restart command.

One use case is using `named-checkconf -z /etc/named.conf && service named restart` as the restart command to prevent the module from restarting BIND if there are syntax errors in `named.conf` or any of the zone files `named.conf` loads.

The defaults are set to `service ${servicename} reload`, which is what was hard-coded into `manifests/service.pp` before.
