### PR TITLE
Allow use of alternate templates for config and other files

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -114,6 +114,7 @@ define bind::server::conf (
   file { $title:
     notify  => Class['bind::service'],
     content => template($config_template),
+    require => Class['bind::package'],
   }
 
 }

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -79,6 +79,7 @@
 #  }
 #
 define bind::server::conf (
+  $config_template        = 'bind/named.conf.erb',
   $acls                   = {},
   $masters                = {},
   $listen_on_port         = '53',
@@ -112,7 +113,7 @@ define bind::server::conf (
   # Everything is inside a single template
   file { $title:
     notify  => Class['bind::service'],
-    content => template('bind/named.conf.erb'),
+    content => template($config_template),
   }
 
 }

--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -29,15 +29,16 @@
 #  }
 #
 define bind::server::file (
-  $zonedir     = '/var/named',
-  $owner       = 'root',
-  $group       = undef,
-  $mode        = '0640',
-  $dirmode     = '0750',
-  $source      = undef,
-  $source_base = undef,
-  $content     = undef,
-  $ensure      = undef,
+  $zonedir      = '/var/named',
+  $owner        = 'root',
+  $group        = undef,
+  $mode         = '0640',
+  $dirmode      = '0750',
+  $source       = undef,
+  $source_base  = undef,
+  $content      = undef,
+  $content_base = undef,
+  $ensure       = undef,
 ) {
 
   include '::bind::params'
@@ -60,13 +61,16 @@ define bind::server::file (
     }
   }
 
+  if $content_base { $zone_content = template("${content_base}${title}") }
+  elsif $content   { $zone_content = $content }
+
   file { "${zonedir}/${title}":
     ensure  => $ensure,
     owner   => $owner,
     group   => $bindgroup,
     mode    => $mode,
     source  => $zone_source,
-    content => $content,
+    content => $zone_content,
     notify  => Class['::bind::service'],
     # For the parent directory
     require => [


### PR DESCRIPTION
We had this need a while back, and I just spent the time to bring it up to date with your master branch.
