### PR TITLE
Add more changes relating to authorative only servers

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -48,9 +48,18 @@
 #  $dnssec_enable:
 #   Enable DNSSEC support. Default: 'yes'
 #  $dnssec_validation:
-#   Enable DNSSEC validation. Default: 'yes'
+#   Enable DNSSEC validation. Default: 'auto'
 #  $dnssec_lookaside:
-#   DNSSEC lookaside type. Default: 'auto'
+#   DNSSEC lookaside type. Default: empty
+#  $bindkeys_file:
+#   The pathname of a file to override the built-in trusted keys provided by named
+#  $hostname
+#   The host-name (a quotes string) the server should report via a query of the
+#   name hostname.bind with type TXT, class CHAOS.  Specifying none disables.
+#   Defaut: None
+#  $server_id
+#   The ID the server will return via a query for ID.SERVER with type TXT,
+#   under class CH (CHAOS). Default: empty
 #  $zones:
 #   Hash of managed zones and their configuration. The key is the zone name
 #   and the value is an array of config lines. Default: empty
@@ -102,18 +111,23 @@ define bind::server::conf (
   $check_names            = [],
   $extra_options          = {},
   $dnssec_enable          = 'yes',
-  $dnssec_validation      = 'yes',
-  $dnssec_lookaside       = 'auto',
+  $dnssec_validation      = 'auto',
+  $dnssec_lookaside       = undef,
+  $bindkeys_file          = undef,
+  $hostname               = 'none',
+  $server_id              = undef,
   $zones                  = {},
   $includes               = [],
   $views                  = {},
 ) {
 
   # Everything is inside a single template
+  file { $directory:
+      ensure => directory,
+  }
   file { $title:
     notify  => Class['bind::service'],
     content => template('bind/named.conf.erb'),
   }
-
 }
 

--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -31,7 +31,7 @@
 define bind::server::file (
   $zonedir     = '/var/named',
   $owner       = 'root',
-  $group       = undef,
+  $group       = $::bind::params::bindgroup,
   $mode        = '0640',
   $dirmode     = '0750',
   $source      = undef,

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -81,11 +81,16 @@ options {
 
 <% end -%>
     dnssec-enable <%= @dnssec_enable %>;
+<%- if @recursion == 'yes' -%>
     dnssec-validation <%= @dnssec_validation %>;
+  <%- if @dnssec_lookaside -%>
     dnssec-lookaside <%= @dnssec_lookaside %>;
+  <% end -%>
 
-    /* Path to ISC DLV key */
-    bindkeys-file "/etc/named.iscdlv.key";
+  <%- if @bindkeys_file -%>
+    bindkeys-file "<%= @bindkeys_file %>";
+  <% end -%>
+<% end -%>
 };
 
 logging {
@@ -143,7 +148,6 @@ view "<%= key %>" {
 };
 <% end -%>
 <% else -%><%# end views, start no views -%>
-
 <% if @recursion == 'yes' -%>
 zone "." IN {
     type hint;


### PR DESCRIPTION
This change disables, the following parameters as they are not relevant in authoritative only server and where causing high CPU usage
   * dnssec-validation
   * dnssec-lookaside
I have also changed the default value for dnssec-lookaside, this gives recursive operators a method of disabling dnssec-lookaside. I have added an additional parameter for bindkeys_file instead of having one hard coded in server.conf. the one you have in your config dose not exist on ubuntu 12.04 LTS however the default one (bind.keys) does. I also changed the default of dnssec-validation to auto which i think makes more sense then yes.

Finally it looks like this pull request has some documentation and a few other small fixes missed from my last pull

John