### PR TITLE
add keys support

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -54,6 +54,9 @@
 #  $zones:
 #   Hash of managed zones and their configuration. The key is the zone name
 #   and the value is an array of config lines. Default: empty
+#  $tsig:
+#   Hash of managed tsig keys and their configuration. The key is the tsig keys name
+#   and the value is an array of config lines. Default: empty
 #  $includes:
 #   Array of absolute paths to named.conf include files. Default: empty
 #
@@ -74,6 +77,12 @@
 #        'type slave',
 #        'file "slaves/example.org"',
 #        'masters { mymasters; }',
+#      ],
+#    }
+#    keys                 => { 
+#      'example.org-tsig' => [
+#        'algorithm hmac-md5',
+#        'secret "aaabbbcccddd"',
 #      ],
 #    }
 #  }
@@ -105,6 +114,7 @@ define bind::server::conf (
   $dnssec_validation      = 'yes',
   $dnssec_lookaside       = 'auto',
   $zones                  = {},
+  $keys                   = {},
   $includes               = [],
   $views                  = {},
 ) {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -13,6 +13,16 @@ acl <%= key %> {
 
 <% end -%>
 <% end -%>
+<% if !@keys.empty? -%>
+<% @keys.sort_by {|key, value| key}.each do |key,value| -%>
+key "<%= key %>" {
+<% value.each do |line| -%>
+    <%= line %>;
+<% end -%>
+};
+
+<% end -%>
+<% end -%>
 <% if !@masters.empty? -%>
 <% @masters.sort_by {|key, value| key}.each do |key,value| -%>
 masters <%= key %> {


### PR DESCRIPTION
Add support for tsig keys.  This is similar to #50 however it uses a hash of arrays instead of a hash or hash's to make the config more inline with the zones hash.  it is also missing some of the other changes which seem to be unrelated.  

Personally i would prefer a hash of hash's however i thought it best to make this compatible with the zones hash and changing the zones hash would make current configs incompatible.  