### PR TITLE
move bind package require to zonedir

### DIFF
--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -53,10 +53,13 @@ define bind::server::file (
 
   if ! defined(File[$zonedir]) {
     file { $zonedir:
-      ensure => directory,
-      owner  => $owner,
-      group  => $bindgroup,
-      mode   => $dirmode,
+      ensure  => directory,
+      owner   => $owner,
+      group   => $bindgroup,
+      mode    => $dirmode,
+      require => [
+        Class['::bind::package'],
+      ],
     }
   }
 
@@ -70,10 +73,8 @@ define bind::server::file (
     notify  => Class['::bind::service'],
     # For the parent directory
     require => [
-      Class['::bind::package'],
       File[$zonedir],
     ],
   }
-
 }
 


### PR DESCRIPTION
$zonedir by default does nothing if the ::bind::package is installed.
If you do not use the default, you need the package installed so
that the parent directory will exist. 

Moving the Class['::bind::package']require from "${zonedir}/${title}" 
to $zonedir permits subdirs of $zonedir, such as for views.
