### PR TITLE
override servicename for CentOS/RHEL7 using chroot

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@ class bind (
     true  => '-chroot',
     false => '',
   }
+  if ($::osfamily == 'RedHat' and $operatingsystemmajrelease >= 7) {
+    $servicename = 'named-chroot'
+  }
   class { 'bind::package':
     packagenameprefix => $packagenameprefix,
     packagenamesuffix => $packagenamesuffix,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,8 @@ class bind (
     true  => '-chroot',
     false => '',
   }
-  if ($::osfamily == 'RedHat' and $operatingsystemmajrelease >= 7) {
+  if ($chroot and $::osfamily == 'RedHat'
+      and $operatingsystemmajrelease >= 7) {
     $servicename = 'named-chroot'
   }
   class { 'bind::package':


### PR DESCRIPTION
if you don't do this, things almost work, but it starts a named that doesn't read from the chroot. oops.