### PR TITLE
Add support for different system includes when recursion is used

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -109,6 +109,25 @@ define bind::server::conf (
   $views                  = {},
 ) {
 
+  # If recursion is enabled
+  if $recursion == 'yes' {
+    # If debian, add /etc/bind/named.conf.default-zones to includes
+    case $::osfamily {
+      'Debian': {
+        $recursion_includes = ['/etc/bind/named.conf.default-zones']
+      }
+      default: {
+        $recursion_includes = ['/etc/named.rfc1912.zones']
+        $recursion_zones = {
+          '.' => [
+            'type hint',
+            'file "named.ca"',
+          ],
+        }
+      }
+    }
+  }
+
   # Everything is inside a single template
   file { $title:
     notify  => Class['bind::service'],

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -144,13 +144,6 @@ view "<%= key %>" {
 <% end -%>
 <% else -%><%# end views, start no views -%>
 
-<% if @recursion == 'yes' -%>
-zone "." IN {
-    type hint;
-    file "named.ca";
-};
-
-<% end -%>
 <% if !@zones.empty? -%>
 <% @zones.sort_by {|key, value| key}.each do |key,value| -%>
 zone "<%= key %>" IN {
@@ -158,11 +151,22 @@ zone "<%= key %>" IN {
     <%= line %>;
 <% end -%>
 };
+<% end -%>
+<% end -%>
 
+<% if @recursion_zones and !@recursion_zones.empty? -%>
+<% @recursion_zones.sort_by {|key, value| key}.each do |key,value| -%>
+zone "<%= key %>" IN {
+<% value.each do |line| -%>
+    <%= line %>;
+<% end -%>
+};
 <% end -%>
 <% end -%>
-<% if @recursion == 'yes' -%>
-include "/etc/named.rfc1912.zones";
+<% if @recursion_includes and !@recursion_includes.empty? -%>
+<% @recursion_includes.each do |filename| -%>
+include "<%= filename %>";
+<% end -%>
 <% end -%>
 <% end -%><%# end no views -%>
 <% if !@includes.empty? -%>


### PR DESCRIPTION
Using recursion does not work out of the box on debian because
the hardcoded /etc/named.rfc1912.zones and named.ca files do not
exist on Debian (Wheezy). This change adds support for this
while reverting to previously defined behaviour for non-debian
releases.
