### PR TITLE
Adjusting named.conf template to fix a bug whereby a view without a v…

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -128,6 +128,7 @@ view "<%= key %>" {
     };
 
 <% end -%>
+<% end -%>
 <% if !@zones.empty? -%>
     /* Global zones */
 <% @zones.sort_by {|key, value| key}.each do |key,value| -%>
@@ -137,7 +138,6 @@ view "<%= key %>" {
 <% end -%>
     };
 
-<% end -%>
 <% end -%>
 <% end -%>
 };


### PR DESCRIPTION
This pull request contains modifications to the named.conf template to address a bug that surfaces in the case where a view is defined without any view-specific zones.

In this situation, the view is generated in named.conf without any of the global zones included.

It appears that this is occurring because the logic that populates the global zones within a view exists within the conditional statement that determines whether or not to populate any view-specific zones (based on whether or not value['zones'] is empty).

By closing this conditional statement before to the logic that populates global zones, global zones will now be added to views without view-specific zones defined. 