### PR TITLE
Allow for Global zones to be defined in views without zones.

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -128,6 +128,7 @@ view "<%= key %>" {
     };
 
 <% end -%>
+<% end -%>
 <% if !@zones.empty? -%>
     /* Global zones */
 <% @zones.sort_by {|key, value| key}.each do |key,value| -%>
@@ -137,7 +138,6 @@ view "<%= key %>" {
 <% end -%>
     };
 
-<% end -%>
 <% end -%>
 <% end -%>
 };


### PR DESCRIPTION
The named.conf.erb template will not copy global zones into a view
if that view has no view-specific zones. This PR will always put @zones
within any view.