### PR TITLE
Updated conf.pp to control permissions and ownership of /etc/named.conf

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -118,12 +118,17 @@ define bind::server::conf (
   $keys                   = {},
   $includes               = [],
   $views                  = {},
+  $binduser               = $::bind::params::binduser,
+  $bindgroup              = $::bind::params::bindgroup,
 ) {
 
   # Everything is inside a single template
   file { $title:
     notify  => Class['::bind::service'],
     content => template('bind/named.conf.erb'),
+    owner   => $binduser,
+    group   => $bindgroup,
+    mode    => '0644',
   }
 
 }


### PR DESCRIPTION
I noticed that /etc/named.conf's ownership and permissions were not being managed.  The user and group is being sourced from the conf.pp and my testing worked on Red Hat, Centos and Ubuntu clients.