### PR TITLE
Fixed bind::server::conf dependency.

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -120,10 +120,15 @@ define bind::server::conf (
   $views                  = {},
 ) {
 
+  include '::bind::params'
+
   # Everything is inside a single template
   file { $title:
     notify  => Class['::bind::service'],
     content => template('bind/named.conf.erb'),
+    require => [
+      Class['::bind::package'],
+    ],
   }
 
 }


### PR DESCRIPTION
Hi,

this is a minor change, which fixes dependency of server::conf on the package. It will not cause any trouble during first instalation any more. It is a simplier version of #43

The change was copied from bind::server::file in order to get those two files in sync.

I will be more than happy if you merge this.