### PR TITLE
Added support for configuring forward mode

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -22,6 +22,8 @@
 #  $hostname:
 #   Hostname returned for hostname.bind TXT in CHAOS. Set to 'none' to disable.
 #   Default: undef, bind internal default
+#  $forward:
+#   Specific forwarding mode forward ( first | only );. Default: undef, empty
 #  $server_id:
 #   ID returned for id.server TXT in CHAOS. Default: undef, empty
 #  $version:
@@ -99,6 +101,7 @@ define bind::server::conf (
   $directory              = '/var/named',
   $managed_keys_directory = undef,
   $hostname               = undef,
+  $forward                = undef,
   $server_id              = undef,
   $version                = undef,
   $dump_file              = '/var/named/data/cache_dump.db',

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -43,6 +43,9 @@ options {
 <% if !@forwarders.empty? -%>
     forwarders { <%= @forwarders.join("; ") %>; };
 <% end -%>
+<% if @forward -%>
+    forward "<%= @forward %>";
+<% end -%>
     directory "<%= @directory %>";
 <% if @managed_keys_directory -%>
     managed-keys-directory "<%= @managed_keys_directory %>";

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -44,7 +44,7 @@ options {
     forwarders { <%= @forwarders.join("; ") %>; };
 <% end -%>
 <% if @forward -%>
-    forward "<%= @forward %>";
+    forward <%= @forward %>;
 <% end -%>
     directory "<%= @directory %>";
 <% if @managed_keys_directory -%>


### PR DESCRIPTION
Adds support for bind forward mode:
options {
        forwarders {
                8.8.8.8;
                8.8.4.4;
        };
        forward only;
};

Set using option: 
bind::server::conf { '/etc/named.conf':
    forward => 'only',
}