### PR TITLE
Add switch to allow logging to syslog

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -60,6 +60,8 @@
 #   and the value is an array of config lines. Default: empty
 #  $includes:
 #   Array of absolute paths to named.conf include files. Default: empty
+#  $syslog:
+#   Log to syslog instead of `/var/log/named/named.log`.  Default: false
 #
 # Sample Usage :
 #  bind::server::conf { '/etc/named.conf':
@@ -118,6 +120,7 @@ define bind::server::conf (
   $keys                   = {},
   $includes               = [],
   $views                  = {},
+  $syslog                 = false,
 ) {
 
   # Everything is inside a single template

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -100,11 +100,16 @@ options {
 
 logging {
     channel main_log {
+    <% if @syslog -%>
+        syslog daemon;
+        severity info;
+    <% else -%>
         file "/var/log/named/named.log" versions 3 size 5m;
         severity info;
         print-time yes;
         print-severity yes;
         print-category yes;
+    <% end -%>
     };
     category default{
         main_log;


### PR DESCRIPTION
Adds a boolean parameter to allow logging configuration to point at syslog rather than `/var/log/named/named.log`.  Addresses issue #80.