### PR TITLE
changed bind user for RedHat from root to named

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class bind::params {
     'RedHat': {
       $packagenameprefix = 'bind'
       $servicename       = 'named'
-      $binduser          = 'root'
+      $binduser          = 'named'
       $bindgroup         = 'named'
     }
     'Debian': {


### PR DESCRIPTION
Both RH itself and CentOS ship with '-u named' in their init scripts.