### PR TITLE
- fix debian default zones

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "thias-bind",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "Matthias Saou",
   "license": "Apache-2.0",
   "summary": "BIND DNS server module",

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -157,7 +157,7 @@ view "<%= key %>" {
 <% end -%>
 <% else -%><%# end views, start no views -%>
 
-<% if @recursion == 'yes' -%>
+<% if @recursion == 'yes' and @osfamily != 'Debian' -%>
 zone "." IN {
     type hint;
     file "<%= @file_hint %>";


### PR DESCRIPTION
Under Debian, with your latest changes, if i have recursion enabled, the "." domain is included twice, which results in a service unavailability