### PR TITLE
Add disable_empty_zone config option for bind

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -62,6 +62,8 @@
 #   and the value is an array of config lines. Default: empty
 #  $includes:
 #   Array of absolute paths to named.conf include files. Default: empty
+#  $disable_empty_zone:
+#   Array of zones for which empty zone responses are disabled. Default: empty
 #
 # Sample Usage :
 #  bind::server::conf { '/etc/named.conf':
@@ -120,6 +122,7 @@ define bind::server::conf (
   $zones                  = {},
   $keys                   = {},
   $includes               = [],
+  $disable_empty_zone     = [],
   $views                  = {},
 ) {
 

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -99,6 +99,12 @@ options {
 
     /* Path to ISC DLV key */
     bindkeys-file "/etc/named.iscdlv.key";
+
+<% if !@disable_empty_zone.empty? -%>
+<% @disable_empty_zone.each do |emptyzone| -%>
+    disable-empty-zone "<%= emptyzone %>";
+<% end -%>
+<% end -%>
 };
 
 logging {


### PR DESCRIPTION
Hi,

Great work on producing such a useful module :) Just wondering if it would be possible to extend it with the following additional option?

I'm already running the module with the attached code successfully in our environment on RHEL 7.

Thanks,

Philip