### PR TITLE
do not add hint for Debian stretch,bionic,cosmic

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,16 @@ class bind::params {
       $servicename       = 'bind9'
       $binduser          = 'bind'
       $bindgroup         = 'bind'
-      $file_hint         = '/etc/bind/db.root'
+      case $facts['lsbdistcodename'] {
+        # newer Debian releases include the hint in the named.conf.default-zones
+        # bind fails to start with duplicate declarations
+        /^(stretch|bionic|cosmic)$/: {
+          $file_hint = undef
+        }
+        default: {
+          $file_hint = '/etc/bind/db.root'
+        }
+      }
       $file_rfc1912      = '/etc/bind/named.conf.default-zones'
     }
     'Freebsd': {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -157,12 +157,14 @@ view "<%= key %>" {
 <% end -%>
 <% else -%><%# end views, start no views -%>
 
+<% unless @file_hint.nil? -%>
 <% if @recursion == 'yes' -%>
 zone "." IN {
     type hint;
     file "<%= @file_hint %>";
 };
 
+<% end -%>
 <% end -%>
 <% if !@zones.empty? -%>
 <% @zones.sort_by {|key, value| key}.each do |key,value| -%>


### PR DESCRIPTION
I am moving some of my CentOS server service to debian family servers.

The more recent Debian flavors/codenames stretch,bionic,cosmic include the "hint" zone in named.conf.default-zones

This change will handle that for those code names. I have successfully tested it on those systems, and the change does not affect others.