### PR TITLE
Allow configuration of logging options

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -62,6 +62,8 @@
 #   and the value is an array of config lines. Default: empty
 #  $includes:
 #   Array of absolute paths to named.conf include files. Default: empty
+#  $logging:
+#   Hash containing channel: hash of channels, and category: hash of categroies
 #
 # Sample Usage :
 #  bind::server::conf { '/etc/named.conf':
@@ -87,6 +89,19 @@
 #        'algorithm hmac-md5',
 #        'secret "aaabbbcccddd"',
 #      ],
+#    }
+#    logging => {
+#      channel => {
+#        foo => [
+#          ' file "/var/named/foo"',
+#          'severity info'
+#        ]
+#      },
+#      category => {
+#        default => [
+#          'foo'
+#        ]
+#      }
 #    }
 #  }
 #
@@ -121,6 +136,7 @@ define bind::server::conf (
   $keys                   = {},
   $includes               = [],
   $views                  = {},
+  $logging                = {},
 ) {
 
   # OS Defaults

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -101,6 +101,28 @@ options {
     bindkeys-file "/etc/named.iscdlv.key";
 };
 
+<% if !@logging.empty? -%>
+logging {
+<% if @logging['channel'] and !@logging['channel'].empty? -%>
+<% @logging['channel'].sort_by {|key,value| key}.each do |key,value| -%>
+    channel <%= key %> {
+<% value.each do |line| -%>
+        <%= line %>;
+<% end -%>
+    }
+<% end -%>
+<% end -%>
+<% if @logging['category'] -%>
+<% @logging['category'].sort_by {|key,value| key}.each do |key,value| -%>
+<% if !value.empty? -%>
+    category <%= key %> { <%= value.join('; ') %>; };
+<% else -%>
+    category <%= key %> { };
+<% end -%>
+<% end -%>
+<% end -%>
+};
+<% else -%>
 logging {
     channel main_log {
         file "/var/log/named/named.log" versions 3 size 5m;
@@ -116,6 +138,8 @@ logging {
         null;
     };
 };
+<% end -%>
+
 <% if !@views.empty? -%>
 
 <% @views.sort_by {|key,value| key}.each do |key,value| -%>


### PR DESCRIPTION
This PR allows configuration of the bind logging options via an additional parameter to the bind::server::conf define.  If undefined, then the previous default configuration is used.