### PR TITLE
Disable file_hint on Ubuntu (fixes startup error)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,8 +16,13 @@ class bind::params {
       $servicename       = 'bind9'
       $binduser          = 'bind'
       $bindgroup         = 'bind'
-      $file_hint         = '/etc/bind/db.root'
       $file_rfc1912      = '/etc/bind/named.conf.default-zones'
+
+      if $::operatingsystem == 'Ubuntu' {
+        $file_hint = false
+      } else {
+        $file_hint = '/etc/bind/db.root'
+      }
     }
     'Freebsd': {
       $packagenameprefix = 'bind910'

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -157,7 +157,7 @@ view "<%= key %>" {
 <% end -%>
 <% else -%><%# end views, start no views -%>
 
-<% if @recursion == 'yes' -%>
+<% if @recursion == 'yes' && @file_hint -%>
 zone "." IN {
     type hint;
     file "<%= @file_hint %>";


### PR DESCRIPTION
Ubuntu defines the "." zone in /etc/bind/named.conf.default-zones

Adding it again leads to an error on startup:

```
/etc/bind/named.conf.default-zones:2: zone '.': already exists previous definition: /etc/bind/named.conf:49
```