### PR TITLE
replace legacy-facts with modern ones

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,8 @@ class bind (
   if $chroot == true {
     $packagenamesuffix = '-chroot'
     # Different service name with chroot on RHEL7+)
-    if $::osfamily == 'RedHat' and
-        versioncmp($::operatingsystemrelease, '7') >= 0 {
+    if $facts['os']['family'] == 'RedHat' and
+        versioncmp($facts['os']['release']['major'], '7') >= 0 {
       $servicenamesuffix = '-chroot'
     } else {
       $servicenamesuffix = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 #
 class bind::params {
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
       $packagenameprefix = 'bind'
       $servicename       = 'named'
@@ -10,7 +10,7 @@ class bind::params {
       $bindgroup         = 'named'
       $file_hint         = 'named.ca'
       $file_rfc1912      = '/etc/named.rfc1912.zones'
-      if versioncmp($::operatingsystemrelease, '8') >= 0 {
+      if versioncmp($facts['os']['release']['major'], '8') >= 0 {
         $file_bindkeys   = '/etc/named.root.key'
       } else {
         $file_bindkeys   = '/etc/named.iscdlv.key'


### PR DESCRIPTION
Newer puppet-agents have legacy-facts disabled by default. So in order to make this module usable out of the box again those facts have to be updated to their modern form.