### PR TITLE
bind::server: add param to change the path of named-checkzone

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,12 +16,13 @@
 #  }
 #
 class bind (
-  $chroot            = false,
-  $service_reload    = true,
-  $servicename       = $::bind::params::servicename,
-  $packagenameprefix = $::bind::params::packagenameprefix,
-  $binduser          = $::bind::params::binduser,
-  $bindgroup         = $::bind::params::bindgroup,
+  $chroot               = false,
+  $service_reload       = true,
+  $servicename          = $::bind::params::servicename,
+  $packagenameprefix    = $::bind::params::packagenameprefix,
+  $binduser             = $::bind::params::binduser,
+  $bindgroup            = $::bind::params::bindgroup,
+  $named_checkzone_path = '/usr/sbin/named-checkzone',
 ) inherits ::bind::params {
 
   # Chroot differences

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,13 +3,11 @@
 # For backwards compatibility. Use the main bind class instead.
 #
 class bind::server (
-  $chroot            = false,
-  $packagenameprefix = $::bind::params::packagenameprefix,
+  $chroot               = false,
+  $packagenameprefix    = $::bind::params::packagenameprefix,
 ) inherits ::bind::params {
-
-  class { '::bind':
+  class { 'bind':
     chroot            => $chroot,
     packagenameprefix => $packagenameprefix,
   }
-
 }

--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -78,7 +78,7 @@ define bind::server::file (
     source       => $zone_source,
     content      => $content,
     replace      => $replace,
-    validate_cmd => "/usr/sbin/named-checkzone -k fail -m fail -M fail -n fail -r fail -S fail -T warn -W warn ${zonename} %",
+    validate_cmd => "${bind::named_checkzone_path} -k fail -m fail -M fail -n fail -r fail -S fail -T warn -W warn ${zonename} %",
     notify       => Class['::bind::service'],
     # For the parent directory
     require      => [


### PR DESCRIPTION
We are using currently using the https://ppa.launchpadcontent.net/isc/bind/ubuntu repos and a recent change updated the path of named-checkzone to `/usr/bin/named-checkzone `.  This PR allows users to configure the path 