### PR TITLE
RHEL10 (bind > 9.18.0) dnssec-enable deprecated / dnssec-lookaside ob…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,9 @@ class bind::params {
       } else {
         $file_bindkeys   = '/etc/named.iscdlv.key'
       }
+      if versioncmp($facts['os']['release']['major'], '10') >= 0 {
+        $bind9_18_depre  = true
+      }
     }
     'Debian': {
       $packagenameprefix = 'bind9'

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -125,9 +125,10 @@ define bind::server::conf (
 
   # OS Defaults
   include '::bind::params'
-  $file_hint = $::bind::params::file_hint
-  $file_rfc1912 = $::bind::params::file_rfc1912
-  $file_bindkeys = $::bind::params::file_bindkeys
+  $file_hint      = $::bind::params::file_hint
+  $file_rfc1912   = $::bind::params::file_rfc1912
+  $file_bindkeys  = $::bind::params::file_bindkeys
+  $bind9_18_depre = $::bind::params::bind9_18_depre
 
   # Everything is inside a single template
   file { $title:

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -93,9 +93,11 @@ options {
 <% end -%>
 
 <% end -%>
-    dnssec-validation <%= @dnssec_validation %>;
-<% if @os['name'] == 'RedHat' and @os['release']['major'].to_i < 10 -%>
+<% if !@bind9_18_depre -%>
     dnssec-enable <%= @dnssec_enable %>;
+<% end -%>
+    dnssec-validation <%= @dnssec_validation %>;
+<% if !@bind9_18_depre -%>
     dnssec-lookaside <%= @dnssec_lookaside %>;
 <% end -%>
 

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -93,9 +93,11 @@ options {
 <% end -%>
 
 <% end -%>
-    dnssec-enable <%= @dnssec_enable %>;
     dnssec-validation <%= @dnssec_validation %>;
+<% if @os['name'] == 'RedHat' and @os['release']['major'].to_i < 10 -%>
+    dnssec-enable <%= @dnssec_enable %>;
     dnssec-lookaside <%= @dnssec_lookaside %>;
+<% end -%>
 
     /* Path to ISC DLV key */
     bindkeys-file "<%= @file_bindkeys %>";


### PR DESCRIPTION
Conditional options remove for RHEL10 (bind-9.18.33)

https://bind9.readthedocs.io/en/

dnssec-enable
in version 9.16.0 the dnssec-enable option was made obsolete
    and in 9.18.0 the option was entirely removed.
DNSSEC responses are always enabled if signatures and other DNSSEC data are present. [GL #866]

dnssec-lookaside
in version 9.16.0 the dnssec-lookaside option was made obsolete
DNSSEC Lookaside Validation (DLV) is now obsolete.