### PR TITLE
Update rake,puppet & facter to minimum security patch version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 
 # gem "rails"
 gem 'rspec-puppet'
-gem 'rake'
-gem 'puppet'
+gem "rake", ">= 12.3.3"
+gem "puppet", ">= 6.25.1"
 gem 'puppetlabs_spec_helper'
 gem 'puppet-lint'
+gem "facter", ">= 2.4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,81 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    facter (1.7.0)
-    hiera (1.2.0)
-      json_pure
-    json_pure (1.7.7)
-    metaclass (0.0.1)
-    mocha (0.13.3)
-      metaclass (~> 0.0.1)
-    puppet (3.1.1)
-      facter (~> 1.6)
-      hiera (~> 1.0)
-    puppet-lint (0.3.2)
-    puppetlabs_spec_helper (0.4.1)
-      mocha (>= 0.10.5)
+    concurrent-ruby (1.3.5)
+    deep_merge (1.2.2)
+    diff-lcs (1.6.2)
+    facter (4.10.0)
+      hocon (~> 1.3)
+      thor (>= 1.0.1, < 1.3)
+    fast_gettext (3.1.0)
+      prime
+    forwardable (1.3.3)
+    getoptlong (0.2.1)
+    hocon (1.4.0)
+    locale (2.1.4)
+    mocha (1.16.1)
+    multi_json (1.17.0)
+    pathspec (1.1.3)
+    prime (0.1.4)
+      forwardable
+      singleton
+    puppet (8.10.0)
+      concurrent-ruby (~> 1.0)
+      deep_merge (~> 1.0)
+      facter (>= 4.3.0, < 5)
+      fast_gettext (>= 2.1, < 4)
+      getoptlong (~> 0.2.0)
+      locale (~> 2.1)
+      multi_json (~> 1.13)
+      puppet-resource_api (~> 1.5)
+      scanf (~> 1.0)
+      semantic_puppet (~> 1.0)
+    puppet-lint (5.1.0)
+    puppet-resource_api (1.9.0)
+      hocon (>= 1.0)
+    puppet-syntax (3.3.0)
+      puppet (>= 5)
       rake
-      rspec (>= 2.9.0)
-      rspec-puppet (>= 0.1.1)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
-    rspec-puppet (0.1.6)
-      rspec
+    puppetlabs_spec_helper (6.0.1)
+      mocha (~> 1.0)
+      pathspec (>= 0.2, < 2.0.0)
+      puppet-lint (>= 3.0.0)
+      puppet-syntax (~> 3.0)
+      rspec-github (~> 2.0)
+      rspec-puppet (>= 2.0)
+    rake (13.3.1)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-github (2.4.0)
+      rspec-core (~> 3.0)
+    rspec-mocks (3.13.7)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-puppet (5.0.0)
+      rspec (~> 3.0)
+    rspec-support (3.13.6)
+    scanf (1.0.0)
+    semantic_puppet (1.1.1)
+    singleton (0.3.0)
+    thor (1.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  puppet
+  facter (>= 2.4.1)
+  puppet (>= 6.25.1)
   puppet-lint
   puppetlabs_spec_helper
-  rake
+  rake (>= 12.3.3)
   rspec-puppet
+
+BUNDLED WITH
+   2.7.2


### PR DESCRIPTION
security: upgrade Puppet, Facter, and Rake to address vulnerabilities and improve compatibility

* Upgraded `puppet` to version `>= 6.25.1`
* Upgraded `facter` to version `>= 2.4.1`
* Upgraded `rake` to version `>= 12.3.3` (fixes CVE-2020-8130)
